### PR TITLE
change install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ biggs is a small ruby gem/rails plugin for formatting postal addresses from over
 
 As a ruby gem:
    
-    sudo gem install yolk-biggs
+    sudo gem install biggs
    
 If your rather prefer to install it as a plugin for rails, from your application directory simply run:
    


### PR DESCRIPTION
`gem install yolk-biggs` uses gems.github.com, which is no longer maintained.
