### PR TITLE
Add support for Curaçao and Kosovo addresses

### DIFF
--- a/country_names.yml
+++ b/country_names.yml
@@ -239,6 +239,7 @@ vn: Vietnam
 vu: Vanuatu
 wf: Wallis and Futuna
 ws: Samoa
+xk: Kosovo
 ye: Yemen
 yt: Mayotte
 za: South Africa

--- a/formats.yml
+++ b/formats.yml
@@ -343,6 +343,11 @@ us: |-
     {{street}}
     {{city}} {{state}} {{zip}}
     {{country}}
+xk: |-
+    {{recipient}}
+    {{street}}
+    {{zip}} {{city}}
+    {{country}}
 ye: |-
     {{recipient}}
     {{street}}


### PR DESCRIPTION
I'm not sure that these are the best references for the address formats but they represent what we have found generally:

Curaçao
https://www.informatica.com/products/data-quality/data-as-a-service/address-verification/address-formats.html?code=CUW

Kosovo
https://www.informatica.com/products/data-quality/data-as-a-service/address-verification/address-formats.html?code=XKS